### PR TITLE
Corregida información sobre la duración de la película y su país.

### DIFF
--- a/filmaffinity.xml
+++ b/filmaffinity.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scraper framework="1.1" date="2010-10-08">
+<scraper framework="1.1" date="2011-11-19">
 	<!-- -->
 	<NfoUrl dest="3">
 		<RegExp input="$$1" output="&lt;url&gt;http://www.filmaffinity.com/es/film\1.html&lt;/url&gt;" dest="3">
 			<expression noclean="1">filmaffinity.com/es/film([0-9]*)</expression>
 		</RegExp>
 	</NfoUrl>
-	<!-- Creación de la pagina web de búsquedas de filmaffinity -->
+	<!-- Creación de la página web de búsquedas de filmaffinity -->
 	<CreateSearchUrl SearchStringEncoding="iso-8859-1" dest="3">
 		<RegExp input="$$1" output="&lt;url&gt;http://www.filmaffinity.com/es/search.php?stext=\1&amp;amp;stype=none&lt;/url&gt;" dest="3">
 			<expression noclean="1" />
@@ -49,7 +49,7 @@
 			</RegExp>
 			
 			<RegExp input="$$1" output="&lt;country&gt;\1&lt;/country&gt;" dest="5+">
-				<expression>&lt;td &gt;&lt;img src="/imgs/countries/...jpg" title="([^"]*)</expression>
+				<expression>&lt;img src="/imgs/countries/...jpg" title="([^"]*)</expression>
 			</RegExp>
 			
 			<RegExp input="$$9" output="&lt;year&gt;\1&lt;/year&gt;" dest="5+">
@@ -96,7 +96,7 @@
 			</RegExp>
 			
 			<RegExp input="$$1" output="&lt;runtime&gt;\1&lt;/runtime&gt;" dest="5+">
-				<expression>&lt;th&gt;DURACI&Oacute;N&lt;/th&gt;\s*&lt;td&gt;\s*&lt;div style=&quot;float: right\;&quot;&gt;>\s*&lt;a href=[^&gt;]*&gt;\s*&lt;/div&gt;\s*([0-9]*) min\.&lt;/td&gt;</expression>
+				<expression>&lt;/a&gt;\s*&lt;/div&gt;\s*([0-9]*) min\.\s*&lt;/td&gt;</expression>
 			</RegExp>
 			
 			<!-- Descarga el listado de actores de filmaffinity (Pocos resultados y sin el rol que realizan en la película) -->


### PR DESCRIPTION
He hecho mil pruebas y siempre que yo codifico el archivo en utf-8 en el diff cambia todas las líneas con tildes.
Se me ha ocurrido por fin dejarlo en ansi y parece que ahora sólo cambia las líneas que debería cambiar.

¿Tu archivo está en utf-8? Cuando me descargo tu ramal al pc con el tortoisegit me aparece como ansi, y entonces si lo pongo en utf-8 toma las tildes como si las hubiese cambiado.

No se que más probar. Lo dejo así.
