### PR TITLE
mejoras en búsqueda de miniatura y pósters

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 [B]1.4.3[/B]
 
-- Mejorada la búsqueda para usar el año y corregidas limitaciones de búsqueda en google (gracias a pancheto)
+- Mejorada la búsqueda para usar el año y corregidas limitaciones de búsqueda en google (gracias a Lechu)
+- Mejorada la búsqueda de miniaturas y pósters (gracias a Lechu)
 
 [B]1.4.2[/B]
 


### PR DESCRIPTION
no sé si es así como debo pedírtelo, pero aquí te va lo último que he hecho para mejorar la obtención de miniaturas y pósters de filmaffinity. son cambios muy pequeños, pero permiten salvar alguna situación en la que la carátula de la película no se encontraba por culpa del código de filmaffinity.
