### PR TITLE
mejoras en búsqueda de miniatura y pósters

### DIFF
--- a/filmaffinity.xml
+++ b/filmaffinity.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <scraper framework="1.1" date="2011-11-21">
 	<!-- -->
 	<NfoUrl dest="3">
@@ -116,7 +116,7 @@
 			
 			<!-- Descargar todos los posters que haya en filmaffinity -->
 			<RegExp conditional="EnableFilmAffinityPosters" input="$$1" output="&lt;url function=&quot;GetFilmAffinityPosters&quot;&gt;http://www.filmaffinity.com/es/filmimages.php\1&lt;/url&gt;" dest="5+">
-				<expression noclean="1">&lt;a href="/es/filmimages.php([^"]+)</expression>
+				<expression noclean="1">(\?movie_id[^"]+)</expression>
 			</RegExp>
 
 			<!-- URL to Google and IMDB (Original+title+year) -->
@@ -124,7 +124,7 @@
 			<RegExp input="$$9" output="&lt;url function=&quot;GoogleToIMDB&quot;&gt;http://www.google.com/search?q=imdb\1&btnI=745&pws=0&lt;/url&gt;" dest="5+">
 				<RegExp input="$$8" output="+\1" dest="9">
 					<RegExp input="$$1" output="\1" dest="8">
-						<expression>&lt;th&gt;T&amp;Iacute\;TULO ORIGINAL&lt;/th&gt;\s*&lt;td&gt;&lt;strong&gt;([^&lt;]*)&lt;/strong&gt;&lt;/td&gt;</expression>
+						<expression>&lt;th&gt;T&amp;Iacute\;TULO ORIGINAL&lt;/th&gt;\s*&lt;td&gt;&lt;strong&gt;([^(\(&lt;)]*).*&lt;/strong&gt;&lt;/td&gt;</expression>
 					</RegExp>
 					<expression repeat="yes">([^ ,]+)</expression>
 				</RegExp>
@@ -229,7 +229,10 @@
 	<GetFilmAffinityPosters dest="5">
 		<RegExp input="$$10" output="&lt;details&gt;\1&lt;/details&gt;" dest="5">
 			<RegExp input="$$1" output="&lt;thumb&gt;http://pics.filmaffinity.com/\1&lt;/thumb&gt;" dest="10">
-				<expression repeat="yes" noclean="1">url_l: 'http://pics.filmaffinity.com/([^']*)', description: '', type_id: 'Posters',</expression>
+				<expression repeat="yes" noclean="1">url_l: \'http://pics.filmaffinity.com/([^\']*)\', description: \'\', type_id: \'Poster</expression>
+			</RegExp>
+			<RegExp input="$$1" output="&lt;thumb&gt;http://pics.filmaffinity.com/\1&lt;/thumb&gt;" dest="10+">
+				<expression noclean="1">"http://pics.filmaffinity.com/([^"]*)</expression>
 			</RegExp>
 			<expression noclean="1" />
 		</RegExp>


### PR DESCRIPTION
envío los últimos cambios realizados en el scraper a fin de conseguir más información gráfica en caso de no encontrar el código fuente necesario para trazarla. incluyo además una revisión de la búsqueda de imdb_id a través de google, ya que películas con información extra entre paréntesis alteraba los resultados.
