### PR TITLE
removing extra blank spaces

### DIFF
--- a/filmaffinity.xml
+++ b/filmaffinity.xml
@@ -192,6 +192,11 @@
 				<expression>Filmaffinity</expression>
 			</RegExp>
 
+			<!-- eliminamos todos los espacios en blanco que hayan aparecido por el camino -->
+			<RegExp input="$$5" output="\1 " dest="5">
+				<expression repeat="yes" noclean="1">(\S+)</expression>
+			</RegExp>
+			
 			<!-- y le devolvemos todos los detalles al señor XBMC -->
 			<expression noclean="1" />
 		</RegExp>


### PR DESCRIPTION
added a regex function at the end of the GetDetails section to remove extra blank spaces that may have been pulled from FilmAffinity code. it's not perfect, since it generates a single and practically unnoticeable " " character just before the "</details>" tag, but it's preferable considering the code cleaning performed.
