### PR TITLE
ligero cambio en la nueva funcionalidad de set scraping

### DIFF
--- a/filmaffinity.xml
+++ b/filmaffinity.xml
@@ -266,10 +266,11 @@
 			<RegExp conditional="ExtraiMDB" input="" output="&lt;url function=&quot;GetImdbStuff&quot;&gt;http://www.imdb.com/title/tt$$6&lt;/url&gt;" dest="5+">
 				<expression />
 			</RegExp>
-            <!-- obtención de colección -->
-            <RegExp input="$$2" output="&lt;chain function=&quot;GetTMDBSetByIdChain&quot;&gt;$$6&lt;/chain&gt;" dest="5+">
-                <expression />
-            </RegExp>
+			
+			<!-- obtención de colección desde TMDb-->
+			<RegExp input="$$2" output="&lt;chain function=&quot;GetTMDBSetByIdChain&quot;&gt;tt$$6&lt;/chain&gt;" dest="5+">
+				<expression />
+			</RegExp>
 
 			<expression noclean="1" />
 		</RegExp>


### PR DESCRIPTION
la búsqueda que tiene que hacer GetTMDBSetByIdChain es &gt;tt$$6&lt; y no %gt;$$6&lt;
añadidos esos 2 caracteres "tt" la funcionalidad es totalmente válida. comprobado en mi biblioteca.
una vez se corrige esta búsqueda y se activa en XBMC lo de agrupar colecciones, efectivamente las agrupa.
