### PR TITLE
pequeños retoques al changelog

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 [B]1.4.5[/B]
 
-- Añadida la posibilidad de descargar información de colecciones.
+- Añadida la posibilidad de descargar información de colecciones de TMDb.
 
 [B]1.4.4[/B]
 
@@ -8,6 +8,7 @@
 - Mejorada la obtención de productoras desde filmaffintiy.
 - Corregido bug en descarga de primera productora cuando miniaturas de estudio está activo.
 - Añadido soporte completamente funcional para descargas de posters de Alpacine.
+- Eliminados todos los espacios en blanco extras en todos los textos descargados.
 
 [B]1.4.3[/B]
 


### PR DESCRIPTION
faltaba por añadir la funcionalidad de eliminación de espacios en blanco en todo el texto. como vino ya de un pull de agjacome lo he metido en esa nota de versión v1.4.4

además apunto el hecho de que la funcionalidad de descarga de colecciones es de TMDb, porque ya que este scraper está pensado para FA no está de más aclarar que bebe de muchas fuentes para enriquecerse.
