### PR TITLE
revisiones menores a en las búsquedas de google y de IMDB

### DIFF
--- a/filmaffinity.xml
+++ b/filmaffinity.xml
@@ -28,11 +28,8 @@
 				<expression repeat="yes" noclean="1,2,3">&lt;a href=&quot;/es/film([0-9]*)\.html&quot;&gt;([^&lt;]*)&lt;/a&gt;[^\(]*\(([0-9]{4})</expression>
 			</RegExp>
 			<!-- búsqueda de google -->
-			<RegExp conditional="GoogleAdvSearch" input="$$5" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;url&gt;http://www.filmaffinity.com/es/film\1.html&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/entity&gt;" dest="5">
-				<RegExp input="$$1" output="\1 \2" dest="5">
-					<expression>www.filmaffinity.com/es/film([0-9]*).html[^&lt;]*(.*?)&lt;/a&gt;</expression>
-				</RegExp>
-				<expression>([0-9]*) (.*) -</expression>
+			<RegExp conditional="GoogleAdvSearch" input="$$1" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;url&gt;http://www.filmaffinity.com/es/film\1.html&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/entity&gt;" dest="5">
+				<expression>/film([0-9]*)[^&gt;]*&gt;(.*?)&lt;/a&gt;</expression>
 			</RegExp>
 			<expression noclean="1" />
 		</RegExp>
@@ -164,8 +161,9 @@
 			<RegExp conditional="!EnableFastSearch" input="$$9" output="&lt;url function=&quot;GetIMDBid&quot;&gt;\1&lt;/url&gt;" dest="5+">
 				<!-- descomponemos en palabras el título original y las unimos con "+" -->
 				<RegExp input="$$12" output="\1+" dest="9">
-					<!-- caracteres válidos: letras en cualquier idioma, números, y aperturas de paréntesis -->
-					<expression repeat="yes">([\p{L}\p{N}\(]+)</expression>
+					<!-- son válidos aperturas de paréntesis, letras mayúsculas y minúsculas, números, -->
+					<!-- y caracteres latinos "singulares" (fuente: http://www.ascii.cl/htmlcodes.htm) -->
+					<expression repeat="yes">([\(A-Za-z0-9\xC0-\xFF]+)</expression>
 				</RegExp>
 				<!-- búsqueda en imdb, sin el año -->
 				<RegExp conditional="!GoogleAdvSearch" input="$$9" output="http://www.imdb.com/xml/find?xml=1&nr=1&tt=on&q=\1" dest="9">
@@ -257,11 +255,11 @@
 				</RegExp>
 				<!-- coincidencia con apellido de director -->
 				<RegExp input="$$1" output="\1" dest="6">
-					<expression>tt([0-9]*)[^&lt;]+&lt;Description&gt;[0-9]{4}[^g,&gt;]*,[^&gt;]+[^&lt;]+($$14,)</expression>
+					<expression>tt([0-9]*)[^&lt;]+&lt;Description&gt;[0-9]{4}[^g,&gt;]*,[^&gt;]+[^&lt;]+($$14,)&lt;</expression>
 				</RegExp>
 				<!-- coincidencia con año y apellido de director -->
 				<RegExp input="$$1" output="\1" dest="6">
-					<expression>tt([0-9]*)[^&lt;]+&lt;Description&gt;$$13[^g,&gt;]*,[^&gt;]+[^&lt;]+($$14,)</expression>
+					<expression>tt([0-9]*)[^&lt;]+&lt;Description&gt;$$13[^g,&gt;]*,[^&gt;]+[^&lt;]+($$14,)&lt;</expression>
 				</RegExp>
 				<expression noclean="1" />
 			</RegExp>


### PR DESCRIPTION
ligeras modificaciones en la búsqueda de google para ser más genéricas (visto que los resultados de google no se limitaban a la versión española de FA a nivel de URL), en la búsqueda del IMDBid para buscar texto en caracteres ASCII (visto que los caracteres Unicode no se procesaban correctamente en el Apple TV), y en el refinado de la búsqueda del IMDBid para forzar que la búsqueda de director sea por apellido (lo cual es más acertado).
