### PR TITLE
refinando la anterior mejora en la búsqueda de google

### DIFF
--- a/filmaffinity.xml
+++ b/filmaffinity.xml
@@ -34,7 +34,7 @@
 			</RegExp>
 			<!-- búsqueda de google -->
 			<RegExp conditional="GoogleAdvSearch" input="$$1" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;url&gt;http://www.filmaffinity.com/es/film\1.html&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/entity&gt;" dest="5">
-				<expression repeat="yes">/film([0-9]*).html&amp;[^&gt;]*&gt;(.*?)( - &lt;b&gt;FilmAffinity&lt;/b&gt;)?&lt;/a&gt;</expression>
+				<expression repeat="yes">/film([0-9]*).html&amp;[^&gt;]*&gt;(.*?)( - [&lt;F].*?)?&lt;/a&gt;</expression>
 			</RegExp>
 			<expression noclean="1" />
 		</RegExp>


### PR DESCRIPTION
ligero refinamiento para eliminar de manera más laxa la coletilla " - FilmAffinity" de los títulos encontrados con la búsqueda en google. si diera tiempo yo la incluiría dentro de la versión 1.5.5 que debería estar a punto de ser publicada oficialmente.
